### PR TITLE
made script execution instruction clearer

### DIFF
--- a/documentationbasic/ocp4devex/src/main/asciidoc/applicationdeploymentstrategies.asciidoc
+++ b/documentationbasic/ocp4devex/src/main/asciidoc/applicationdeploymentstrategies.asciidoc
@@ -330,7 +330,14 @@ spec:
 
 The host 'URL' will be replaced by the configure-routes.sh shell script. The path shows /adventure, and a similar path exists in the cruise, package and short-break files to point to their specific paths.
 
-Execute the shell script 'configure-routes.sh' and then take another look at adventure-route.yaml which will be similar to that which is shown below.
+Execute the shell script 'configure-routes.sh' with this command:
+
+[source]
+----
+./configure-routes.sh
+----
+
+Now take another look at adventure-route.yaml, which will be similar to that which is shown below.
 
 [source]
 ----


### PR DESCRIPTION
One of the grads had to google how to execute a shell script. I guess most of the audience would know this already, but no harm in making it more explicit. What do you think?