### PR TITLE
updated redis version to 'latest'

### DIFF
--- a/setup/playbooks/roles/deploy_docs/templates/username-distribution.yml.j2
+++ b/setup/playbooks/roles/deploy_docs/templates/username-distribution.yml.j2
@@ -102,7 +102,7 @@ items:
         - redis
         from:
           kind: ImageStreamTag
-          name: redis:3.2
+          name: redis:latest
           namespace: openshift
       type: ImageChange
     - type: ConfigChange


### PR DESCRIPTION
3.2 not available in OCP 4.5