### PR TITLE
Link back from docs to the workshop portal

### DIFF
--- a/labs/_modules.yml
+++ b/labs/_modules.yml
@@ -44,3 +44,5 @@ modules:
     name: Introduction to Quarkus on OpenShift
   codereadyworkspaces:
     name: CodeReady Workspaces
+  linkback:
+    name: Return to the Workshop Portal

--- a/labs/linkback.adoc
+++ b/labs/linkback.adoc
@@ -1,1 +1,1 @@
-To get back to the Workshop Portal, click {{USERNAME_URL}}[here, window="_blank"]
+To get back to the Workshop Portal, click {{USERNAME_URL}}[here]

--- a/labs/linkback.adoc
+++ b/labs/linkback.adoc
@@ -1,0 +1,1 @@
+To get back to the Workshop Portal, click {username_url}[here, window="_blank"]

--- a/labs/linkback.adoc
+++ b/labs/linkback.adoc
@@ -1,1 +1,1 @@
-To get back to the Workshop Portal, click {{USERNAME_URL}}[here]
+To get back to the Workshop Portal, click {{USERNAME_URL}}[here, target="_self"]

--- a/labs/linkback.adoc
+++ b/labs/linkback.adoc
@@ -1,1 +1,1 @@
-To get back to the Workshop Portal, click {username_url}[here, window="_blank"]
+To get back to the Workshop Portal, click {{USERNAME_URL}}[here, window="_blank"]

--- a/setup/playbooks/roles/deploy_docs/tasks/main.yml
+++ b/setup/playbooks/roles/deploy_docs/tasks/main.yml
@@ -16,7 +16,15 @@
 - name: Create httpd application
   k8s:
     state: present
-    definition: "{{ lookup('template', 'httpd.yml.j2') }}" 
+    definition: "{{ lookup('template', 'httpd.yml.j2') }}"
+
+- name: Get route to manifests application
+  k8s:
+    kind: Route
+    namespace: "{{ project_name }}"
+    name: manifests
+    api_version: route.openshift.io/v1
+  register: manifests_routes
 
 - name: Deploy workshopper application
   k8s:

--- a/setup/playbooks/roles/deploy_docs/templates/httpd.yml.j2
+++ b/setup/playbooks/roles/deploy_docs/templates/httpd.yml.j2
@@ -116,5 +116,31 @@ items:
       deploymentconfig: manifests
   status:
     loadBalancer: {}
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    namespace: {{ project_name }}
+    annotations:
+      openshift.io/host.generated: "true"
+    labels:
+      app: manifests
+      app.kubernetes.io/component: manifests
+      app.kubernetes.io/instance: manifests
+      app.kubernetes.io/name: ""
+      app.kubernetes.io/part-of: docs
+      app.openshift.io/runtime: ""
+      app.openshift.io/runtime-version: latest
+    name: manifests
+  spec:
+    port:
+      targetPort: 8080-tcp
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge
+    to:
+      kind: Service
+      name: manifests
+      weight: 100
+    wildcardPolicy: None
 kind: List
 metadata: {}

--- a/setup/playbooks/roles/deploy_docs/templates/manifestConfigMap.yml.j2
+++ b/setup/playbooks/roles/deploy_docs/templates/manifestConfigMap.yml.j2
@@ -14,11 +14,13 @@ data:
       url: https://raw.githubusercontent.com/utherp0/workshop4/master/labs
 
     vars:
-      OPENSHIFT_CONSOLE_URL: "https://console-openshift-console.mycluster.com"
+      OPENSHIFT_CONSOLE_URL: "will be overwritten"
+      USERNAME_URL: "will be overwritten"
 
     modules:
       activate:
 {% for lab in item.labs %}
       {{ "- " + lab.id }}
 {% endfor %}
+      - linkback
 {% endfor %}

--- a/setup/playbooks/roles/deploy_docs/templates/workshopper.yml.j2
+++ b/setup/playbooks/roles/deploy_docs/templates/workshopper.yml.j2
@@ -33,6 +33,9 @@ spec:
           envFrom:
             - configMapRef:
                 name: docs
+          env:
+            - name: USERNAME_URL
+              value: "https://username-distribution-{{ project_name }}-{{ manifests_routes.result.spec.host.split('.')[1:] | join('.') }}"
           resources: {}
 ---
 apiVersion: v1

--- a/setup/playbooks/roles/deploy_docs/templates/workshopper.yml.j2
+++ b/setup/playbooks/roles/deploy_docs/templates/workshopper.yml.j2
@@ -35,7 +35,7 @@ spec:
                 name: docs
           env:
             - name: USERNAME_URL
-              value: "https://username-distribution-{{ project_name }}-{{ manifests_routes.result.spec.host.split('.')[1:] | join('.') }}"
+              value: "https://username-distribution-{{ project_name }}.{{ manifests_routes.result.spec.host.split('.')[1:] | join('.') }}"
           resources: {}
 ---
 apiVersion: v1


### PR DESCRIPTION
Dynamically adds a new lab to each "module" so that users can find their way back to the username-distribution app