### PR TITLE
Removed placeholder for rocket chat link

### DIFF
--- a/setup/playbooks/group_vars/all/links
+++ b/setup/playbooks/group_vars/all/links
@@ -1,5 +1,3 @@
 extra_urls:
-  - title: Rocket Chat
-    url: <URL OF ROCKET CHAT>
   - title: Bored? Play the Pod Escape game
     url: https://podescape.io

--- a/setup/playbooks/roles/deploy_docs/templates/username-distribution.yml.j2
+++ b/setup/playbooks/roles/deploy_docs/templates/username-distribution.yml.j2
@@ -12,7 +12,7 @@ items:
     - annotations: null
       from:
         kind: DockerImage
-        name: quay.io/browningjp/username-distribution:latest
+        name: quay.io/openshiftlabs/username-distribution:latest
       generation: 2
       importPolicy: {}
       name: latest


### PR DESCRIPTION
I've removed the placeholder for the rocket chat link, as it is often left in causing a dead link